### PR TITLE
Fix showing popup elements on initial page load

### DIFF
--- a/blocks/popup/_opened/popup_opened.css
+++ b/blocks/popup/_opened/popup_opened.css
@@ -1,5 +1,4 @@
 .popup_opened {
-  display: flex;
   visibility: visible;
   opacity: 1;
   height: 100vh;

--- a/blocks/popup/_opened/popup_opened.css
+++ b/blocks/popup/_opened/popup_opened.css
@@ -1,9 +1,4 @@
 .popup_opened {
   visibility: visible;
   opacity: 1;
-  height: 100vh;
-  -webkit-transition: opacity .3s ease-in-out, height 0s linear;
-  -moz-transition: opacity .3s ease-in-out, height 0s linear;
-  -o-transition: opacity .3s ease-in-out, height 0s linear;
-  transition: opacity .3s ease-in-out, height 0s linear;
 }

--- a/blocks/popup/popup.css
+++ b/blocks/popup/popup.css
@@ -9,10 +9,10 @@
   top: 0;
   left: 0;
   width: 100vw;
-  height: 0;
+  height: 100vh;
   background-color: rgba(0,0,0,0.5);
-  -webkit-transition: opacity .3s ease-in-out, visibility 0s linear .3s, height 0s linear .3s;
-  -moz-transition: opacity .3s ease-in-out, visibility 0s linear .3s, height 0s linear .3s;
-  -o-transition: opacity .3s ease-in-out, visibility 0s linear .3s, height 0s linear .3s;
-  transition: opacity .3s ease-in-out, visibility 0s linear .3s, height 0s linear .3s;
+  -webkit-transition: all .3s ease-in-out;
+  -moz-transition: all .3s ease-in-out;
+  -o-transition: all .3s ease-in-out;
+  transition: all .3s ease-in-out;
 }

--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mesto</title>
     <link rel="stylesheet" href="./pages/index.css">
-    <script src="initial-cards.js" defer></script>
-    <script src="script.js" defer></script>
 </head>
 <body class="page">
     <header class="header page__header">
@@ -82,5 +80,8 @@
         </div>
       </li>
     </template>
+
+    <script src="initial-cards.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When there is initial page load from github IO, all popup elements that are hidden are shown 1 sec and then disappear. That is due to transition was set both in popup and popup_opened classes.